### PR TITLE
Revert formatting change & manually adjust

### DIFF
--- a/lib/prawn/emoji/image.rb
+++ b/lib/prawn/emoji/image.rb
@@ -22,7 +22,13 @@ module Prawn
       private
 
       def codepoint
-        @codepoint ||= @unicode.codepoints.map { |c| '%04x' % c.to_s }.join.upcase
+        @codepoint ||= @unicode.codepoints.map { |c| format_codepoint(c) }.join.upcase
+      end
+
+      def format_codepoint(codepoint)
+        codepoint = codepoint.to_s(16)
+        codepoint = "00#{codepoint}" if codepoint.size == 2
+        codepoint
       end
     end
   end


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/118362951

Previous formatting change was incomplete (we need to be brought in line with parent repo), doing this as temporary workaround.

Long term solution is to replace our fork as explicit dependency with original gem, but it requires other dependency upgrades (Prawn).
